### PR TITLE
Refactoring: ICC operations and config parser

### DIFF
--- a/config/config_processor.go
+++ b/config/config_processor.go
@@ -3,12 +3,7 @@ package config
 import (
 	"encoding/json"
 	"errors"
-	"image"
-	icc "imagetools/icc"
-	image_parser "imagetools/image_parser"
 	op "imagetools/operation"
-	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,68 +55,6 @@ type ProfileConfig struct {
 	ICC         string        // ICC profile to embed
 	Resize      *ResizeConfig // Resize option
 	Output      *OutputConfig // Output file configuraion
-}
-
-func (profile ProfileConfig) DoCrop(in image.Image) (image.Image, error) {
-	return in, nil
-}
-
-// Embed ICC profile to image.
-func (profile ProfileConfig) DoEmbedIcc(out io.Writer, in io.Reader) error {
-
-	parsed_image, err := image_parser.Parse(in)
-	if err != nil {
-		return err
-	}
-
-	err = icc.EmbedIccProfile(profile.ICC, parsed_image)
-	if err != nil {
-		return err
-	}
-
-	_, err = parsed_image.WriteTo(out)
-
-	return err
-}
-
-func (profile ProfileConfig) ProcessFile(out io.Writer, in io.Reader) error {
-
-	// Procedure: Decode -> image ops -> encode -> segment ops -> write out
-
-	working_image, err := op.CreateImageFromReader(in)
-	if err != nil {
-		log.Printf("[x] Error while creating image: %v", err)
-		return err
-	}
-
-	// Do crop
-	//img, err = profile.DoCrop(img)
-	//if err != nil {
-	//	log.Printf("[x] Error while cropping image: %v", err)
-	//	return err
-	//}
-
-	output_image := working_image.
-		Then(op.Decode()).
-		ThenIf(profile.Resize.Factor != 0.0, op.ResizeImageByFactor(profile.Resize.Algorithm, profile.Resize.Factor)).
-		ThenIf((profile.Resize.Factor == 0.0) && (profile.Resize.Width != 0), op.ResizeImageByWidth(profile.Resize.Algorithm, profile.Resize.Width)).
-		ThenIf((profile.Resize.Factor == 0.0) && (profile.Resize.Width == 0) && (profile.Resize.Height != 0), op.ResizeImageByHeight(profile.Resize.Algorithm, profile.Resize.Height)).
-		Then(op.Encode(profile.Output.Format, (*op.EncoderOption)(profile.Output.Options))).
-		ThenIf((profile.Output.Format == "jpeg" || profile.Output.Format == "jpg") && profile.ICC != "", op.EmbedProfile(profile.ICC)) // Supports jpeg only for now, will be extended to other formats.
-
-	if output_image.LastError() != nil {
-		log.Printf("[x] Error while processing image: %v", output_image.LastError())
-		return output_image.LastError()
-	}
-
-	// Write output to writer.
-	output_image.Then(op.WriteImageToWriter(out))
-	if output_image.LastError() != nil {
-		log.Printf("[x] Error while writing image: %v", output_image.LastError())
-		return output_image.LastError()
-	}
-
-	return nil
 }
 
 type OutputDirConfig struct {

--- a/config/config_processor.go
+++ b/config/config_processor.go
@@ -101,13 +101,6 @@ func (profile ProfileConfig) ProcessFile(out io.Writer, in io.Reader) error {
 	//	return err
 	//}
 
-	// Do embed ICC
-	//err = profile.DoEmbedIcc(out, &buf)
-	//if err != nil {
-	//	log.Printf("[x] Error while embedding ICC profile: %v", err)
-	//	return err
-	//}
-
 	output_image := working_image.
 		Then(op.Decode()).
 		ThenIf(profile.Resize.Factor != 0.0, op.ResizeImageByFactor(profile.Resize.Algorithm, profile.Resize.Factor)).
@@ -117,12 +110,14 @@ func (profile ProfileConfig) ProcessFile(out io.Writer, in io.Reader) error {
 		ThenIf((profile.Output.Format == "jpeg" || profile.Output.Format == "jpg") && profile.ICC != "", op.EmbedProfile(profile.ICC)) // Supports jpeg only for now, will be extended to other formats.
 
 	if output_image.LastError() != nil {
+		log.Printf("[x] Error while processing image: %v", output_image.LastError())
 		return output_image.LastError()
 	}
 
 	// Write output to writer.
 	output_image.Then(op.WriteImageToWriter(out))
 	if output_image.LastError() != nil {
+		log.Printf("[x] Error while writing image: %v", output_image.LastError())
 		return output_image.LastError()
 	}
 

--- a/config/config_processor.go
+++ b/config/config_processor.go
@@ -113,7 +113,8 @@ func (profile ProfileConfig) ProcessFile(out io.Writer, in io.Reader) error {
 		ThenIf(profile.Resize.Factor != 0.0, op.ResizeImageByFactor(profile.Resize.Algorithm, profile.Resize.Factor)).
 		ThenIf((profile.Resize.Factor == 0.0) && (profile.Resize.Width != 0), op.ResizeImageByWidth(profile.Resize.Algorithm, profile.Resize.Width)).
 		ThenIf((profile.Resize.Factor == 0.0) && (profile.Resize.Width == 0) && (profile.Resize.Height != 0), op.ResizeImageByHeight(profile.Resize.Algorithm, profile.Resize.Height)).
-		Then(op.Encode(profile.Output.Format, (*op.EncoderOption)(profile.Output.Options)))
+		Then(op.Encode(profile.Output.Format, (*op.EncoderOption)(profile.Output.Options))).
+		ThenIf((profile.Output.Format == "jpeg" || profile.Output.Format == "jpg") && profile.ICC != "", op.EmbedProfile(profile.ICC)) // Supports jpeg only for now, will be extended to other formats.
 
 	if output_image.LastError() != nil {
 		return output_image.LastError()

--- a/icc/icc_preset.go
+++ b/icc/icc_preset.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 )
 
+// Predefined Display-P3 ICC profile compressed and base64 encoded.
 var display_p3 = `H4sIAOOBGmEC/2NgYFJJLCjIYWFgYMjNKykKcndSiIiMUmB/yMAOhLwMYgwKicnFBY4BAT5AJQww
 GhV8u8bACKIv64LMOiU1tUm1XsDXYqbw1YuvRJsY8AOulNTiZCD9B4hTkwuKShgYGFOAbOXykgIQ
 uwPIFikCOgrIngNip0PYG0DsJAj7CFhNSJAzkH0DyFZIzkgEmsH4A8jWSUIST0diQ+0FAW6XzOKC
@@ -18,6 +19,7 @@ fQYG2/3////fjRDz2s/AsBGok2snQkzDgoFBkJuB4cTOgsSiRLAQMxAzpaUxMHxazsDAG8nAIHwB
 qCe6OM3YCCzPyOPEwMB67///z2oMDOyTGRj+Tvj///ei////LgZqvsPAcCAPAJ+/MZ4kAgAA
 `
 
+// Predefined DCI-P3 ICC profile compressed and base64 encoded.
 var dci_p3 = `H4sIAKSEGmEC/2NgYFJJLCjIYWFgYMjNKykKcndSiIiMUmC/z8DFwMfAy8DBYJGYXFzgGBDgA1TC
 AKNRwbdrDIwg+rIuyKxgR76Vv87e/B1+pqSt9/1hewb8gCsltTgZSP8B4vLkgqISBgZGIGZQLi8p
 ALFnANkiRUBHAdlrQOx0CPsAiJ0EYV8BqwkJcgayXwDZAskZiSlA9g8gWycJSTwdiQ21FwRkg30D
@@ -26,6 +28,7 @@ gaEpAwMoDiCqn7JAwvZLKEKsppSBwYrj////pxFiQUA/bb3BwMAtiBBTrwR6E8g+EVCQWJQIdwDT
 zFnFacZGYDaj0DMGBs73//9/62Ng4LMCxuWJ////hPz//w9oHmM0A8Od+wBS2VCSJAIAAA==
 `
 
+// Predefined ROMM-RGB ICC profile compressed and base64 encoded.
 var romm_rgb = `H4sIABSFGmEC/2NgYDJJLCjIYWFgYMjNKykKcndSiIiMUmC/z8DFwMfAy8DBYJ6YXFzgGBDgA1TC
 AKNRwbdrDIwg+rIuyKzCJ1HPFj9NFGo8wyVrNSdtLgN+wJWSWpwMpP8AcWlyQVEJAwMjEDMol5cU
 gNgzgGyRIqCjgOw1IHY6hH0AxE6CsK+A1YQEOQPZL4BsheSMxBQGBiYOIFsnCUk8HYkNtRcEpIP8
@@ -34,6 +37,7 @@ GRhAcYAetgixMyYMDJ57QSyEmNIcBoZtdqhiHOxAgg2o16EgsSgRLMQMxIxnzkLMBAEBENFQnGZs
 BOYyojkWCx8AhPHgOTQCAAA=
 `
 
+// Predefined Adobe-RGB ICC profile compressed and base64 encoded.
 var adobe_rgb = `H4sIAJfoGmEC/2NgYDJwdHFyZRJgYMjNKykKcndSiIiMUmC/wMDBwM0gzGDMYJ2YXFzgGBDgwwAE
 efl5qQwY4Ns1BkYQfVkXZBYDaYAruaCoBEj/AWKjlNTiZAYGRgMgO7u8pAAozjgHyBZJygazN4DY
 RSFBzkD2ESCbLx3CvgJiJ0HYT0DsIqAngOwvIPXpYDYTB9gcCFsGxC5JrQDZy+CcX1BZlJmeUaJg
@@ -42,6 +46,7 @@ cPgyip1BiCFAcmlRGZTJyGRMmI8wY44EA4P/UgYGlj8IMZNeBoYFOgwM/FMRYmqGDAwC+gwM++YA
 AIzXb+0wAgAA
 `
 
+// Predefined sRGB ICC profile compressed and base64 encoded.
 var srgb = `H4sIAG+FGmEC/52Wd1RU1xaHz713eqHNMNIZepMuMID0LiAdBFEYZgYYygDDDE1siKhARBERAUWQ
 oIABo6FIrIhiISioYA9IEFBiMIqoqGRG1kp8eXnv5eX3x73f2mfvc/fZe5+1LgAkTx8uLwWWAiCZ
 J+AHejjTV4VH0LH9AAZ4gAGmADBZ6am+Qe7BQCQvNxd6usgJ/IveDAFI/L5l6OlPp4P/T9KsVL4A

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"imagetools/config"
+	op "imagetools/operation"
 	"io"
 	"log"
 	"os"
@@ -48,6 +49,46 @@ func defaultProfileFilePath(profile_name string) (path string, err error) {
 	}
 
 	return profile_file, err
+}
+
+func ProcessFile(profile config.ProfileConfig, out io.Writer, in io.Reader) error {
+
+	// Procedure: Decode -> image ops -> encode -> segment ops -> write out
+
+	working_image, err := op.CreateImageFromReader(in)
+	if err != nil {
+		log.Printf("[x] Error while creating image: %v", err)
+		return err
+	}
+
+	// Do crop
+	//img, err = profile.DoCrop(img)
+	//if err != nil {
+	//	log.Printf("[x] Error while cropping image: %v", err)
+	//	return err
+	//}
+
+	output_image := working_image.
+		Then(op.Decode()).
+		ThenIf(profile.Resize.Factor != 0.0, op.ResizeImageByFactor(profile.Resize.Algorithm, profile.Resize.Factor)).
+		ThenIf((profile.Resize.Factor == 0.0) && (profile.Resize.Width != 0), op.ResizeImageByWidth(profile.Resize.Algorithm, profile.Resize.Width)).
+		ThenIf((profile.Resize.Factor == 0.0) && (profile.Resize.Width == 0) && (profile.Resize.Height != 0), op.ResizeImageByHeight(profile.Resize.Algorithm, profile.Resize.Height)).
+		Then(op.Encode(profile.Output.Format, (*op.EncoderOption)(profile.Output.Options))).
+		ThenIf((profile.Output.Format == "jpeg" || profile.Output.Format == "jpg") && profile.ICC != "", op.EmbedProfile(profile.ICC)) // Supports jpeg only for now, will be extended to other formats.
+
+	if output_image.LastError() != nil {
+		log.Printf("[x] Error while processing image: %v", output_image.LastError())
+		return output_image.LastError()
+	}
+
+	// Write output to writer.
+	output_image.Then(op.WriteImageToWriter(out))
+	if output_image.LastError() != nil {
+		log.Printf("[x] Error while writing image: %v", output_image.LastError())
+		return output_image.LastError()
+	}
+
+	return nil
 }
 
 func main() {
@@ -97,13 +138,14 @@ func main() {
 				outfile_name := pf.Output.GenerateFileName(f)
 
 				outputbuf := bytes.NewBuffer([]byte{})
-				err = pf.ProcessFile(outputbuf, bytes.NewBuffer(raw_bytes))
+				output_full_path := filepath.Join(output_dir, outfile_name)
+
+				err = ProcessFile(pf, outputbuf, bytes.NewBuffer(raw_bytes))
 				if err != nil {
 					log.Printf("[x] An error occurred while processing image: %s\n", err)
 					return
 				}
 
-				output_full_path := filepath.Join(output_dir, outfile_name)
 				ofp, err := os.OpenFile(output_full_path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
 				defer func() {
 					ofp.Close()

--- a/operation/image_icc_profile.go
+++ b/operation/image_icc_profile.go
@@ -1,0 +1,1 @@
+package operation

--- a/operation/image_icc_profile.go
+++ b/operation/image_icc_profile.go
@@ -6,7 +6,7 @@ import (
 	image_parser "imagetools/image_parser"
 )
 
-func (CurrentProcessingImage) EmbedProfile(profile_name string) Operation {
+func EmbedProfile(profile_name string) Operation {
 
 	return func(currentImage CurrentProcessingImage) (CurrentProcessingImage, error) {
 

--- a/operation/image_icc_profile.go
+++ b/operation/image_icc_profile.go
@@ -1,1 +1,54 @@
 package operation
+
+import (
+	"bytes"
+	icc "imagetools/icc"
+	image_parser "imagetools/image_parser"
+)
+
+func (CurrentProcessingImage) EmbedProfile(profile_name string) Operation {
+
+	return func(currentImage CurrentProcessingImage) (CurrentProcessingImage, error) {
+
+		// Input image should in binary format.
+		if !currentImage.IsBinary() {
+			// Change the error state.
+			currentImage.errorState = ErrOperationNotSupportInImage
+			// Return error.
+			return currentImage, ErrOperationNotSupportInImage
+		}
+
+		// Create reader from binary data.
+		r := bytes.NewReader(currentImage.ImageData)
+
+		// Parse binary image to segments.
+		parsed_image, err := image_parser.Parse(r)
+		if err != nil {
+			// Change the error state.
+			currentImage.errorState = err
+			// Return error.
+			return currentImage, err
+		}
+
+		err = icc.EmbedIccProfile(profile_name, parsed_image)
+		if err != nil {
+			// Change the error state.
+			currentImage.errorState = err
+			// Return error.
+			return currentImage, err
+		}
+
+		// Create a buffer to hold the image data.
+		buf := new(bytes.Buffer)
+		_, err = parsed_image.WriteTo(buf)
+		if err != nil {
+			// Change the error state.
+			currentImage.errorState = err
+			// Return error.
+			return currentImage, err
+		}
+
+		return CurrentProcessingImage{ImageData: buf.Bytes(), isBinaryData: true}, nil
+	}
+
+}


### PR DESCRIPTION
- Rewrite the ICC to single operation.
- Now config parser won't include the image process part, we moved it to `main.go`
